### PR TITLE
Add missing pubsub handler features

### DIFF
--- a/sms_connector/lib/opinion_handlers.py
+++ b/sms_connector/lib/opinion_handlers.py
@@ -1,3 +1,140 @@
+import threading
+
+# buffer of opinions to process
+opinion_buffer = []
+opinion_buffer_lock = threading.Lock()
+
+firebase_client = None
+
+# As this is the only process that's allowed to modify firebase we can
+# decrease read costs by an in memory cache
+conversations_map = {}
+_dirty_list_ids = set()
+
+# Very simple scheme to avoid multiple writes to the same firestore element
 def add_opinion(namespace, opinion):
-    print (f"{namespace} : {opinion}")
-    pass
+    with opinion_buffer_lock:
+        opinion_buffer.append((namespace, opinion))
+        print (f"{namespace} : {opinion} buffered")
+    process_buffer()
+
+def process_buffer():
+    global opinion_buffer
+    with opinion_buffer_lock:
+        print (f"Processing: {len(opinion_buffer)}")
+        for (namespace, opinion) in opinion_buffer:
+            print (f" processing {namespace} : {opinion}")
+            assert namespace in NAMESPACE_REACTORS
+            id = opinion["deidentified_phone_number"]
+            _ensure_conversation_loaded(id)
+
+            reactor = NAMESPACE_REACTORS[namespace]
+            reactor(id, opinion)
+        print (f"Processing complete")
+        opinion_buffer = []
+        _clean()
+
+def _ensure_conversation_loaded(id):
+    # If the conversation exists in firebase load it, otherwise create empty
+    print (f"_ensure_conversation_loaded {id}")
+    if id in conversations_map.keys():
+        return
+
+    doc = firebase_client.document(
+        f'nook_conversation_shards/shard-0/conversations/{id}').get()
+
+    if doc.exists:
+        conversations_map[id] = doc.to_dict()
+        return
+
+    conversations_map[id] = _create_empty_conversation_map(id)
+
+def _push_conversation(id):
+    print ("_push_conversation {conv_id}")
+    firebase_client.document(
+        f'nook_conversation_shards/shard-0/conversations/{id}').set(conversations_map[id])
+
+def _clean():
+    global _dirty_list_ids
+    for conv_id in _dirty_list_ids:
+        _push_conversation(conv_id)
+    _dirty_list_ids = set()
+
+
+def _compute_message_id(opinion):
+    return "id"
+
+# {
+#   'deidentified_phone_number': 'nook-phone-uuid-a55a8ddf-7bfc-49c3-a16d-ed0ff369a6b9',
+#   'created_on': '2020-11-14T23:46:05.269955+00:00',
+#   'text': 'T2',
+#   'direction': 'in'
+# }
+def handle_sms_raw_msg(id, opinion):
+    created_on = opinion["created_on"]
+    text = opinion["text"]
+    direction = opinion['direction']
+
+    conversations_map[id]["messages"].append(
+        {
+            "datetime" : created_on,
+            "direction" : direction,
+            "text" : text,
+            "translation" : "",
+            "id" : _compute_message_id(opinion),
+            "tags" : []
+        }
+    )
+    _dirty_list_ids.add(id)
+
+
+def handle_add_conversation_tags(id, opinion):
+    for tag in opinion["tags"]:
+        conversations_map[id]["tags"].add(tag)
+    _dirty_list_ids.add(id)
+
+def handle_remove_conversation_tags(id, opinion):
+    for tag in opinion["tags"]:
+        conversations_map[id]["tags"].remove(tag)
+    _dirty_list_ids.add(id)
+
+def handle_set_notes(id, opinion):
+    conversations_map[id]["notes"] = opinion["notes"]
+    _dirty_list_ids.add(id)
+
+def handle_set_unread(id, opinion):
+    conversations_map[id]["unread"] = True
+    _dirty_list_ids.add(id)
+
+def handle_add_message_tags(id, opinion):
+    print (f"WARNING: handle_add_message_tags not implemented")
+
+def handle_remove_message_tags(id, opinion):
+    print (f"WARNING: handle_remove_message_tags not implemented")
+
+def handle_set_translation(id, opinion):
+    print (f"WARNING: handle_set_translation not implemented")
+
+
+def _create_empty_conversation_map(conversation_id):
+    return {
+        "deidentified_phone_number" : conversation_id,
+        "demographicsInfo" : {},
+        "messages" : [],
+        "notes" : "",
+        "tags" : [],
+        "unread" : True
+    }
+
+
+
+NAMESPACE_REACTORS = {
+    "nook_conversations/add_tags" : handle_add_conversation_tags,
+    "nook_conversations/remove_tags" : handle_remove_conversation_tags,
+    "nook_conversations/set_notes"  : handle_set_notes,
+    "nook_conversations/set_unread"  : handle_set_unread,
+    "nook_messages/add_tags" : handle_add_message_tags,
+    "nook_messages/remove_tags" : handle_remove_message_tags,
+    "nook_messages/set_translation" : handle_set_translation,
+    "sms_raw_msg" : handle_sms_raw_msg
+}


### PR DESCRIPTION
Hi both @danrubel @marianamarasoiu 

Submitting this for any early feedback on the overall layout.  Please do _not_ spend time reviewing `process_buffer` at the moment - it's currently doing everything on every response and will need moving to a polling loop per my discussions with you both.

The general idea is:

- The process maintains an in memory map of all the conversations its touched as it's the only thing writing to Firestore it doesn't need to reread these
- Interactions mutate this map and mark the map as dirty
- On a polling operation the dirty list is written to firebase

There's a method for every namespace entry

Broad scaling intention is for 1000 conversations and 50000 messages.

There's obviously a bunch of detail and tidying up to be done, just sending this now in case either of you felt it should go in a significantly different direction